### PR TITLE
纠正HashMap进行entry遍历的说法

### DIFF
--- a/docs/java/collection/HashMap.md
+++ b/docs/java/collection/HashMap.md
@@ -512,7 +512,8 @@ public class HashMapDemo {
 
         }
         /**
-         * 另外一种不常用的遍历方式
+         * 如果既要遍历key又要value，那么建议这种方式，应为如果先获取keySet然后再执行map.get(key)，map内部会执行两次遍历。
+         * 一次是在获取keySet的时候，一次是在遍历所有key的时候。
          */
         // 当我调用put(key,value)方法的时候，首先会把key和value封装到
         // Entry这个静态内部类对象中，把Entry对象再添加到数组中，所以我们想获取


### PR DESCRIPTION
        /**
         * 另外一种不常用的遍历方式
         */
        // 当我调用put(key,value)方法的时候，首先会把key和value封装到
        // Entry这个静态内部类对象中，把Entry对象再添加到数组中，所以我们想获取
        // map中的所有键值对，我们只要获取数组中的所有Entry对象，接下来
        // 调用Entry对象中的getKey()和getValue()方法就能获取键值对了
        Set<java.util.Map.Entry<String, String>> entrys = map.entrySet();
        for (java.util.Map.Entry<String, String> entry : entrys) {
            System.out.println(entry.getKey() + "--" + entry.getValue());
        }

文章原来的说法是：一种不常用的遍历方式。
这个不是不常用。如果既要遍历key又要value，那么建议这种方式，应为如果先获取keySet然后再执行map.get(key)，map内部会执行两次遍历。 一次是在获取keySet的时候，一次是在遍历所有key的时候。