### PR TITLE
[拼写错误] java线程池学习总结.md

### DIFF
--- a/docs/java/multi-thread/java线程池学习总结.md
+++ b/docs/java/multi-thread/java线程池学习总结.md
@@ -834,7 +834,7 @@ Wed Nov 13 13:40:43 CST 2019::pool-1-thread-5
 
 **`ScheduledThreadPoolExecutor` 的执行主要分为两大部分：**
 
-1. 当调用 `ScheduledThreadPoolExecutor` 的 **`scheduleAtFixedRate()`** 方法或者**`scheduleWirhFixedDelay()`** 方法时，会向 `ScheduledThreadPoolExecutor` 的 **`DelayQueue`** 添加一个实现了 **`RunnableScheduledFuture`** 接口的 **`ScheduledFutureTask`** 。
+1. 当调用 `ScheduledThreadPoolExecutor` 的 **`scheduleAtFixedRate()`** 方法或者 **`scheduleWithFixedDelay()`** 方法时，会向 `ScheduledThreadPoolExecutor` 的 **`DelayQueue`** 添加一个实现了 **`RunnableScheduledFuture`** 接口的 **`ScheduledFutureTask`** 。
 2. 线程池中的线程从 `DelayQueue` 中获取 `ScheduledFutureTask`，然后执行任务。
 
 **`ScheduledThreadPoolExecutor` 为了实现周期性的执行任务，对 `ThreadPoolExecutor`做了如下修改：**


### PR DESCRIPTION
拼写错误修正：`scheduleWirhFixedDelay()` -> `scheduleWithFixedDelay()`