### PR TITLE
fix: 修正单词的错误

### DIFF
--- a/docs/database/MySQL Index.md
+++ b/docs/database/MySQL Index.md
@@ -34,7 +34,7 @@
 
    《高性能MySQL》第四章如是说：And, in case you’re wondering, allowing NULL values in the index really doesn’t impact performance  。NULL 值的索引查找流程参考：https://juejin.im/post/5d5defc2518825591523a1db ,相关阅读：[MySQL中IS NULL、IS NOT NULL、!=不能用索引？胡扯！](https://juejin.im/post/5d5defc2518825591523a1db) 。
 
-9. 删除长期未使用的索引，不用的索引的存在会造成不必要的性能损耗 MySQL 5.7 可以通过查询 sys 库的 chema_unused_indexes 视图来查询哪些索引从未被使用
+9. 删除长期未使用的索引，不用的索引的存在会造成不必要的性能损耗 MySQL 5.7 可以通过查询 sys 库的 schema_unused_indexes 视图来查询哪些索引从未被使用
 
 10. 在使用 limit offset 查询缓慢时，可以借助索引来提高性能
 


### PR DESCRIPTION
查询数据库未使用的表的字段是 `schema_unused_indexes` 而非 `chema_unused_indexes` 单词拼写错误，少了一个 **s**