### PR TITLE
Update Java内存区域.md

### DIFF
--- a/docs/java/jvm/Java内存区域.md
+++ b/docs/java/jvm/Java内存区域.md
@@ -174,8 +174,8 @@ JDK 8 版本之后方法区（HotSpot 的永久代）被彻底移除了（JDK1.7
 
 堆这里最容易出现的就是 OutOfMemoryError 错误，并且出现这种错误之后的表现形式还会有几种，比如：
 
-1. **`OutOfMemoryError: GC Overhead Limit Exceeded`** ： 当 JVM 花太多时间执行垃圾回收并且只能回收很少的堆空间时，就会发生此错误。
-2. **`java.lang.OutOfMemoryError: Java heap space`** :假如在创建新的对象时, 堆内存中的空间不足以存放新创建的对象, 就会引发`java.lang.OutOfMemoryError: Java heap space` 错误。(和本机物理内存无关，和你配置的内存大小有关！)
+1. **`java.lang.OutOfMemoryError: GC Overhead Limit Exceeded`** ： 当 JVM 花太多时间执行垃圾回收并且只能回收很少的堆空间时，就会发生此错误。
+2. **`java.lang.OutOfMemoryError: Java heap space`** :假如在创建新的对象时, 堆内存中的空间不足以存放新创建的对象, 就会引发此错误。(和配置的最大堆内存有关，且受制于物理内存大小。最大堆内存可通过`-Xmx`参数配置，若没有特别配置，将会使用默认值，详见：[Default Java 8 max heap size](https://stackoverflow.com/questions/28272923/default-xmxsize-in-java-8-max-heap-size))
 3. ......
 
 ### 2.5 方法区


### PR DESCRIPTION
主要修改 “OutofMemoryError: Java heap space 和本机物理内存无关，和你配置的内存大小有关！“

修改原因：
是和配置的最大堆内存有关，但最大值是要受限制于物理内存。
如果没有专门配置，默认值可能是物理内存的1/4 或 物理内存其他比例，还是与物理内存有一定关联。