### PR TITLE
Update Java并发进阶常见面试题总结.md

### DIFF
--- a/docs/java/multi-thread/2020最新Java并发进阶常见面试题总结.md
+++ b/docs/java/multi-thread/2020最新Java并发进阶常见面试题总结.md
@@ -479,7 +479,7 @@ static class Entry extends WeakReference<ThreadLocal<?>> {
 
 `Runnable`自 Java 1.0 以来一直存在，但`Callable`仅在 Java 1.5 中引入,目的就是为了来处理`Runnable`不支持的用例。**`Runnable` 接口** 不会返回结果或抛出检查异常，但是 **`Callable` 接口** 可以。所以，如果任务不需要返回结果或抛出异常推荐使用 **`Runnable` 接口** ，这样代码看起来会更加简洁。
 
-工具类 `Executors` 可以实现 `Runnable` 对象和 `Callable` 对象之间的相互转换。（`Executors.callable（Runnable task`）或 `Executors.callable（Runnable task，Object resule）`）。
+工具类 `Executors` 可以实现将 `Runnable` 对象转换成 `Callable` 对象。（`Executors.callable(Runnable task)` 或 `Executors.callable(Runnable task, Object result)`）。
 
 `Runnable.java`
 
@@ -510,9 +510,9 @@ public interface Callable<V> {
 ### 4.3. 执行 execute()方法和 submit()方法的区别是什么呢？
 
 1. **`execute()`方法用于提交不需要返回值的任务，所以无法判断任务是否被线程池执行成功与否；**
-2. **`submit()`方法用于提交需要返回值的任务。线程池会返回一个 `Future` 类型的对象，通过这个 `Future` 对象可以判断任务是否执行成功**，并且可以通过 `Future` 的 `get()`方法来获取返回值，`get()`方法会阻塞当前线程直到任务完成，而使用 `get（long timeout，TimeUnit unit）`方法则会阻塞当前线程一段时间后立即返回，这时候有可能任务没有执行完。
+2. **`submit()`方法用于提交需要返回值的任务。线程池会返回一个 `Future` 类型的对象，通过这个 `Future` 对象可以判断任务是否执行成功**，并且可以通过 `Future` 的 `get()`方法来获取返回值，`get()`方法会阻塞当前线程直到任务完成，而使用 `get(long timeout，TimeUnit unit)`方法则会阻塞当前线程一段时间后立即返回，这时候有可能任务没有执行完。
 
-我们以** `AbstractExecutorService` **接口中的一个 `submit` 方法为例子来看看源代码：
+我们以 **`AbstractExecutorService` 接口** 中的一个 `submit` 方法为例子来看看源代码：
 
 ```java
 public Future<?> submit(Runnable task) {


### PR DESCRIPTION
改动1： 将 “ `Executors` 可以实现 `Runnable` 对象和 `Callable` 对象之间的相互转换."  这句修改成：  `Executors` 可以实现将 `Runnable` 对象转换成 `Callable` 对象。

原因：给出的Executors中的两个方法都是将`Runnable` 对象转换成 `Callable`对象。 如果想将Callable 转换成Runnable，应该是重写Runnable 中的run 方法，其他方法：https://stackoverflow.com/questions/36777592/how-can-we-convert-a-callable-into-a-runnable 
              
改动2： 部分排版问题，code中的中文括号，加粗格式不正确