### PR TITLE
Update spring-common-annotations.md

### DIFF
--- a/docs/system-design/framework/spring/spring-common-annotations.md
+++ b/docs/system-design/framework/spring/spring-common-annotations.md
@@ -125,7 +125,7 @@ public Person personSingleton() {
 - singleton : 唯一 bean 实例，Spring 中的 bean 默认都是单例的。
 - prototype : 每次请求都会创建一个新的 bean 实例。
 - request : 每一次 HTTP 请求都会产生一个新的 bean，该 bean 仅在当前 HTTP request 内有效。
-- session : 每一次 HTTP 请求都会产生一个新的 bean，该 bean 仅在当前 HTTP session 内有效。
+- session : 每一个 HTTP Session 会产生一个新的 bean，该 bean 仅在当前 HTTP session 内有效。
 
 #### 2.5. `@Configuration`
 


### PR DESCRIPTION
官网注释：
Session: Scopes a single bean definition to the lifecycle of a HTTP Session. Only valid in the context of a web-aware Spring ApplicationContext.

来自:
https://docs.spring.io/spring-framework/docs/3.0.0.M3/reference/html/ch04s04.html