### PR TITLE
AtomicMarkableReference 可以解决ABA问题

### DIFF
--- a/docs/java/concurrent/atomic-classes.md
+++ b/docs/java/concurrent/atomic-classes.md
@@ -37,7 +37,7 @@ Atomic 翻译成中文是原子的意思。在化学上，我们知道原子是�
 **引用类型**
 
 - AtomicReference：引用类型原子类
-- AtomicMarkableReference：原子更新带有标记的引用类型。该类将 boolean 标记与引用关联起来，~~也可以解决使用 CAS 进行原子更新时可能出现的 ABA 问题。~~
+- AtomicMarkableReference：原子更新带有标记的引用类型。该类将 boolean 标记与引用关联起来，也可以解决使用 CAS 进行原子更新时可能出现的 ABA 问题。
 - AtomicStampedReference ：原子更新带有版本号的引用类型。该类将整数值与引用关联起来，可用于解决原子的更新数据和数据的版本号，可以解决使用 CAS 进行原子更新时可能出现的 ABA 问题。
 
 **对象的属性修改类型**


### PR DESCRIPTION
因为AtomicMarkableReference是通过内部类Pair实现数据存储，每次替换都是通过Pair.of方法new一个类出来进行替换原先的值
如果ABA出现，那么最后的A肯定是一个新的Pair实例，即当前的A和之前的A不是同一个实例，当线程使用compareAndSet则会返回false
以下是compareAndSet的实现：
public boolean compareAndSet(V       expectedReference,
                       V       newReference,
                       boolean expectedMark,
                       boolean newMark) {
        Pair<V> current = pair;
        return
            expectedReference == current.reference &&
            expectedMark == current.mark &&
            ((newReference == current.reference &&
              newMark == current.mark) ||
             casPair(current, Pair.of(newReference, newMark)));
    }