### PR TITLE
Update spring-design-patterns-summary.md

### DIFF
--- a/docs/system-design/framework/spring/spring-design-patterns-summary.md
+++ b/docs/system-design/framework/spring/spring-design-patterns-summary.md
@@ -276,7 +276,7 @@ public class DemoPublisher {
 
 ## 适配器模式
 
-适配器模式(Adapter Pattern) 将一个接口转换成客户希望的另一个接口，适配器模式使接口不兼容的那些类可以一起工作，其别名为包装器(Wrapper)。
+适配器模式(Adapter Pattern) 将一个接口转换成客户希望的另一个接口，适配器模式使接口不兼容的那些类可以一起工作。
 
 ### spring AOP中的适配器模式	
 


### PR DESCRIPTION
279行，包装器是装饰者的别名，不是适配器；应是笔误，建议删除