### PR TITLE
Java8 新特性实战 自定义一个函数式接口,这里的代码写错了。

### DIFF
--- a/docs/java/new-features/java8-common-new-features.md
+++ b/docs/java/new-features/java8-common-new-features.md
@@ -186,7 +186,7 @@ public class LambdaClass {
     }
     //函数式接口参数
     static void lambdaInterfaceDemo(LambdaInterface i){
-        System.out.println(i);
+        i.f();
     }
 }
 ```


### PR DESCRIPTION
正确应为i.f();
如果按照原来的代码System.out.println(i);运行了一下，无论Lambda表达式里面的内容如何都只是打印类名。
难道是有意为之，那麻烦能加上注释解释这样写的原因。