### PR TITLE
修改了 “Java8 新特性 Date-Time API 格式化” 示例代码的注释

### DIFF
--- a/docs/java/new-features/java8-common-new-features.md
+++ b/docs/java/new-features/java8-common-new-features.md
@@ -766,8 +766,8 @@ LocalTime.class //时间 format: HH:mm:ss
 
 ```java
 public void oldFormat(){
-		Date now = new Date();
-    //format yyyy-MM-dd HH:mm:ss
+    Date now = new Date();
+    //format yyyy-MM-dd
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
     String date  = sdf.format(now);
     System.out.println(String.format("date format : %s", date));


### PR DESCRIPTION
日期格式化 Java 8 之前的示例代码，原注释有误，与示例代码不对应，故此修正