### PR TITLE
修改keepAliveTime参数详解

### DIFF
--- a/docs/java/concurrent/java-concurrent-questions-03.md
+++ b/docs/java/concurrent/java-concurrent-questions-03.md
@@ -308,7 +308,7 @@ public ScheduledThreadPoolExecutor(int corePoolSize) {
 
 `ThreadPoolExecutor`其他常见参数 :
 
-- **`keepAliveTime`**:线程池中的线程数量大于 `corePoolSize` 的时候，如果这时没有新的任务提交，核心线程外的线程不会立即销毁，而是会等待，直到等待的时间超过了 `keepAliveTime`才会被回收销毁；
+- **`keepAliveTime`**:线程池中的线程数量大于 `corePoolSize` 的时候，如果这时没有新的任务提交，多余的空闲线程不会立即销毁，而是会等待，直到等待的时间超过了 `keepAliveTime`才会被回收销毁，线程池回收线程时，会对核心线程和非核心线程一视同仁，直到线程池中线程的数量等于 `corePoolSize` ，回收过程才会停止。
 - **`unit`** : `keepAliveTime` 参数的时间单位。
 - **`threadFactory`** :executor 创建新线程的时候会用到。
 - **`handler`** :饱和策略。关于饱和策略下面单独介绍一下。


### PR DESCRIPTION
销毁并不只针对核心线程，会对核心线程和非核心线程一视同仁。 

也就是allowCoreThreadTimeOut默认是false的情况下，线程数超过corePoolSize时，等待时间大于keepAliveTime，在回收空闲线程时，会对核心线程和非核心线程一视同仁，并不只回收非核心线程中的空闲线程，如果核心线程有空闲的也会回收，直到线程数等于corePoolSize。

额外补充：
allowCoreThreadTimeOut是true的情况下，即使线程数不超过corePollSize，等待时间大于keepAliveTime，即只有核心线程时，也会进行回收。

参见《Java 性能调优实战》