### PR TITLE
全局搜索组件快捷键

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
     <!-- 全文搜索快捷键 -->
     <script>
       document.addEventListener('keydown', function(event) {
-      if ((event.metaKey || event.ctrlKey) && event.key === 'f') {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'g') {
           event.preventDefault();
           document.getElementsByTagName("input")[0].focus();
       }

--- a/index.html
+++ b/index.html
@@ -72,6 +72,15 @@
     <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
     <!--Java代码高亮-->
     <script src="//unpkg.com/prismjs/components/prism-java.js"></script>
+    <!-- 全文搜索快捷键 -->
+    <script>
+      document.addEventListener('keydown', function(event) {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'f') {
+          event.preventDefault();
+          document.getElementsByTagName("input")[0].focus();
+      }
+      });
+    </script>
     <!--全文搜索,直接用官方提供的无法生效-->
     <script src="https://cdn.bootcss.com/docsify/4.5.9/plugins/search.min.js"></script>
     <!--谷歌统计


### PR DESCRIPTION
ctrl+f调用的是浏览器的搜索框，现在新增ctrl+g调用内部搜索框组件，更加便捷。不能用ctrl+f调用搜索组件，因为那样会覆盖浏览器搜索框，不符合预期。
![2](https://github.com/Snailclimb/JavaGuide/assets/108608748/2adb183d-aa0b-4463-a11f-105748304493)
![1](https://github.com/Snailclimb/JavaGuide/assets/108608748/7273a1d3-fdb5-4b6e-a08a-72f9b5e47d63)
