### PR TITLE
Fix code error

### DIFF
--- a/docs/java/new-features/java8-common-new-features.md
+++ b/docs/java/new-features/java8-common-new-features.md
@@ -627,7 +627,7 @@ public class MapAndFlatMapExample {
                 .collect(Collectors.toList());
 
         System.out.println("Using map:");
-        System.out.println(mapResult);
+        mapResult.forEach(arrays-> System.out.println(Arrays.toString(arrays)));
 
         List<String> flatMapResult = listOfArrays.stream()
                 .flatMap(array -> Arrays.stream(array).map(String::toUpperCase))


### PR DESCRIPTION
When using  'System.out.println(mapResult)';

The output appears as follows:
```plain 
[[Ljava.lang.String;@506e6d5e, [Ljava.lang.String;@96532d6, [Ljava.lang.String;@3796751b]
```
To print the arrays properly, they should be formatted as follows:
```java
mapResult.forEach(arrays-> System.out.println(Arrays.toString(arrays)));
```
Outputs:
```plain
[APPLE, BANANA, CHERRY]
[ORANGE, GRAPE, PEAR]
[KIWI, MELON, PINEAPPLE]
```