### PR TITLE
LinkedHashMap勘误

### DIFF
--- a/docs/java/collection/linkedhashmap-source-code.md
+++ b/docs/java/collection/linkedhashmap-source-code.md
@@ -119,7 +119,8 @@ cache.put(1, "one");
 cache.put(2, "two");
 cache.put(3, "three");
 cache.put(4, "four");
-for (int i = 0; i <= 4; i++) {
+cache.put(5, "five");
+for (int i = 1; i <= 5; i++) {
     System.out.println(cache.get(i));
 }
 ```
@@ -128,12 +129,13 @@ for (int i = 0; i <= 4; i++) {
 
 ```java
 null
-two
+null
 three
 four
+five
 ```
 
-从输出结果来看，由于缓存容量为 2 ，因此，添加第 3 个元素时，第 1 个元素会被删除。添加第 4 个元素时，第 2 个元素会被删除。
+从输出结果来看，由于缓存容量为 3 ，因此，添加第 4 个元素时，第 1 个元素会被删除。添加第 5 个元素时，第 2 个元素会被删除。
 
 ## LinkedHashMap 源码解析
 


### PR DESCRIPTION
fix：修改了LRU部分测试代码中for循环起点，如果从0开始和下面代码对不上，同时多加一条数据，且修改了下方描述部分，改为【从输出结果来看，由于缓存容量为 3 ，因此，添加第 4 个元素时，第 1 个元素会被删除。添加第 5 个元素时，第 2 个元素会被删除。 】。