### PR TITLE
修正文章阅读顺序问题，增加连贯性。

### DIFF
--- a/docs/java/basis/java-basic-questions-01.md
+++ b/docs/java/basis/java-basic-questions-01.md
@@ -989,7 +989,7 @@ public class SuperSuperMan extends SuperMan {
 
 ### 什么是可变长参数？
 
-从 Java5 开始，Java 支持定义可变长参数，所谓可变长参数就是允许在调用方法时传入不定长度的参数。就比如下面的这个 `printVariable` 方法就可以接受 0 个或者多个参数。
+从 Java5 开始，Java 支持定义可变长参数，所谓可变长参数就是允许在调用方法时传入不定长度的参数。就比如下面的这个 `method1` 方法就可以接受 0 个或者多个参数。
 
 ```java
 public static void method1(String... args) {

--- a/docs/java/basis/java-basic-questions-01.md
+++ b/docs/java/basis/java-basic-questions-01.md
@@ -989,7 +989,7 @@ public class SuperSuperMan extends SuperMan {
 
 ### 什么是可变长参数？
 
-从 Java5 开始，Java 支持定义可变长参数，所谓可变长参数就是允许在调用方法时传入不定长度的参数。就比如下面的这个 `method1` 方法就可以接受 0 个或者多个参数。
+从 Java5 开始，Java 支持定义可变长参数，所谓可变长参数就是允许在调用方法时传入不定长度的参数。就比如下面这个方法就可以接受 0 个或者多个参数。
 
 ```java
 public static void method1(String... args) {


### PR DESCRIPTION
原文中提到：

> 就比如下面的那个 `printVariable` 方法...

但是实际上下面的两个代码块的方法名分别为 `method1` 和 `method2`，第三个代码块的方法名才为 `printVariable`。

我在阅读时产生疑问，因为正常阅读的情况下我看到 "**下面的这个 `printVariable` 方法**"，就会去下文的代码块寻找，但下文的代码块并不是 `printVariable`，相反是 `method1`。

可以修改为 **下面的这个方法** 或者 **下面的这个 `method1` 方法**，使文章可读性更加连贯。