### PR TITLE
Update java8-tutorial-translate.md

### DIFF
--- a/docs/java/new-features/java8-tutorial-translate.md
+++ b/docs/java/new-features/java8-tutorial-translate.md
@@ -595,7 +595,7 @@ System.out.println(String.format("parallel sort took: %d ms", millis));
 
 ```java
 1000000
-parallel sort took: 475 ms//串行排序所用的时间
+parallel sort took: 475 ms//并行排序所用的时间
 ```
 
 上面两个代码几乎是一样的，但是并行版的快了 50% 左右，唯一需要做的改动就是将 `stream()` 改为`parallelStream()`。


### PR DESCRIPTION
在举例Stream中，Parallel Sort(并行排序)时，列举并行排序的例子里面，代码中的注释写成了“//串行排序所用的时间”。但其实是“//并行排序所用的时间”