### PR TITLE
fix: 修改一处表述不清晰的文字介绍，Update redis-delayed-task.md

### DIFF
--- a/docs/database/redis/redis-delayed-task.md
+++ b/docs/database/redis/redis-delayed-task.md
@@ -72,7 +72,7 @@ Redisson 是一个开源的 Java 语言 Redis 客户端，提供了很多开箱�
 
 Redisson 的延迟队列 RDelayedQueue 是基于 Redis 的 SortedSet 来实现的。SortedSet 是一个有序集合，其中的每个元素都可以设置一个分数，代表该元素的权重。Redisson 利用这一特性，将需要延迟执行的任务插入到 SortedSet 中，并给它们设置相应的过期时间作为分数。
 
-Redisson 使用 `zrangebyscore` 命令扫描 SortedSet 中过期的元素，然后将这些过期元素从 SortedSet 中移除，并将它们加入到就绪消息列表中。就绪消息列表是一个阻塞队列，有消息进入就会被监听到。这样做可以避免对整个 SortedSet 进行轮询，提高了执行效率。
+Redisson 定期使用 `zrangebyscore` 命令扫描 SortedSet 中过期的元素，然后将这些过期元素从 SortedSet 中移除，并将它们加入到就绪消息列表中。就绪消息列表是一个阻塞队列，有消息进入就会被消费者监听到。这样做可以避免消费者对整个 SortedSet 进行轮询，提高了执行效率。
 
 相比于 Redis 过期事件监听实现延时任务功能，这种方式具备下面这些优势：
 


### PR DESCRIPTION
既然是要找到定时过期的任务，肯定需要有定期扫描的，既然消费者没有轮询，那应该就是RDelayedQueue使用zrangebyscore命令定期扫描已经过期的任务。