### PR TITLE
Update atomic-classes.md

### DIFF
--- a/docs/java/concurrent/atomic-classes.md
+++ b/docs/java/concurrent/atomic-classes.md
@@ -341,7 +341,7 @@ Final Reference: Daisy, Final Mark: true
 - `AtomicLongFieldUpdater`：原子更新长整形字段的更新器
 - `AtomicReferenceFieldUpdater`：原子更新引用类型里的字段的更新器
 
-要想原子地更新对象的属性需要两步。第一步，因为对象的属性修改类型原子类都是抽象类，所以每次使用都必须使用静态方法 newUpdater()创建一个更新器，并且需要设置想要更新的类和属性。第二步，更新的对象属性必须使用 public volatile 修饰符。
+要想原子地更新对象的属性需要两步。第一步，因为对象的属性修改类型原子类都是抽象类，所以每次使用都必须使用静态方法 newUpdater()创建一个更新器，并且需要设置想要更新的类和属性。第二步，更新的对象属性必须使用 volatile int 修饰符。
 
 上面三个类提供的方法几乎相同，所以我们这里以 `AtomicIntegerFieldUpdater`为例子来介绍。
 
@@ -351,8 +351,8 @@ Final Reference: Daisy, Final Mark: true
 // Person 类
 class Person {
     private String name;
-    // 要使用 AtomicIntegerFieldUpdater，字段必须是 public volatile
-    private volatile int age;
+    // 要使用 AtomicIntegerFieldUpdater，字段必须是 volatile int
+    volatile int age;
     //省略getter/setter和toString
 }
 


### PR DESCRIPTION
fix:修复需求说明错误
经过实测，实际上字段必须满足的是 volatile int 且不为 private，访问修饰符只要不是 private 即可