### PR TITLE
[docs fix]修正错别字

### DIFF
--- a/docs/java/concurrent/java-concurrent-questions-02.md
+++ b/docs/java/concurrent/java-concurrent-questions-02.md
@@ -475,8 +475,8 @@ synchronized static void method() {
 
 对括号里指定的对象/类加锁：
 
-- `synchronized(object)` 表示进入同步代码库前要获得 **给定对象的锁**。
-- `synchronized(类.class)` 表示进入同步代码前要获得 **给定 Class 的锁**
+- `synchronized(object)` 表示进入同步代码块前要获得 **给定对象的锁**。
+- `synchronized(类.class)` 表示进入同步代码块前要获得 **给定 Class 的锁**
 
 ```java
 synchronized(this) {


### PR DESCRIPTION
作者您好，关于《Java 并发常见面试题总结（中）》一文，在介绍使用 `synchronized` 修饰代码块的部分，有一个错别字，并遗漏了一个字，我已帮您修正。