### PR TITLE
建议:修改RoundingMode的样例中注释采用的数据

### DIFF
--- a/docs/java/basis/bigdecimal.md
+++ b/docs/java/basis/bigdecimal.md
@@ -99,20 +99,20 @@ public BigDecimal divide(BigDecimal divisor, int scale, RoundingMode roundingMod
 
 ```java
 public enum RoundingMode {
-   // 2.5 -> 3 , 1.6 -> 2
-   // -1.6 -> -2 , -2.5 -> -3
+   // 2.4 -> 3 , 1.6 -> 2
+   // -1.6 -> -2 , -2.4 -> -3
    UP(BigDecimal.ROUND_UP),
-   // 2.5 -> 2 , 1.6 -> 1
-   // -1.6 -> -1 , -2.5 -> -2
+   // 2.4 -> 2 , 1.6 -> 1
+   // -1.6 -> -1 , -2.4 -> -2
    DOWN(BigDecimal.ROUND_DOWN),
-   // 2.5 -> 3 , 1.6 -> 2
-   // -1.6 -> -1 , -2.5 -> -2
+   // 2.4 -> 3 , 1.6 -> 2
+   // -1.6 -> -1 , -2.4 -> -2
    CEILING(BigDecimal.ROUND_CEILING),
    // 2.5 -> 2 , 1.6 -> 1
    // -1.6 -> -2 , -2.5 -> -3
    FLOOR(BigDecimal.ROUND_FLOOR),
-   // 2.5 -> 3 , 1.6 -> 2
-   // -1.6 -> -2 , -2.5 -> -3
+   // 2.4 -> 2 , 1.6 -> 2
+   // -1.6 -> -2 , -2.4 -> -2
    HALF_UP(BigDecimal.ROUND_HALF_UP),
    //......
 }


### PR DESCRIPTION
作者您好，在阅读《BigDecimal 详解》一文当中，在介绍使用 RoundingMode的几种模式中，文中的样例注释当中使用了2.5 -2.5 1.6 -1.6这四个数作为的样例，但是对于最后一个四舍五入的方法没有区分度，均为大于5的数进位。所以我提议将2.5改为2.4，-2.5改为-2.4来进行区分，做了如下修改，并且使用java程序已验证正确性，希望可以合并
```
测试数据 2.4, -2.4, 1.6, -1.6
Rounding模式: UP
2.4 -> 3
-2.4 -> -3
1.6 -> 2
-1.6 -> -2
Rounding模式: DOWN
2.4 -> 2
-2.4 -> -2
1.6 -> 1
-1.6 -> -1
Rounding模式: CEILING
2.4 -> 3
-2.4 -> -2
1.6 -> 2
-1.6 -> -1
Rounding模式: FLOOR
2.4 -> 2
-2.4 -> -3
1.6 -> 1
-1.6 -> -2
Rounding模式: HALF_UP
2.4 -> 2
-2.4 -> -2
1.6 -> 2
-1.6 -> -2
```