### PR TITLE
修正类加载器详解中一个错误

### DIFF
--- a/docs/java/jvm/classloader.md
+++ b/docs/java/jvm/classloader.md
@@ -101,7 +101,7 @@ JVM 中内置了三个重要的 `ClassLoader`：
 
 除了 `BootstrapClassLoader` 是 JVM 自身的一部分之外，其他所有的类加载器都是在 JVM 外部实现的，并且全都继承自 `ClassLoader`抽象类。这样做的好处是用户可以自定义类加载器，以便让应用程序自己决定如何去获取所需的类。
 
-每个 `ClassLoader` 可以通过`getParent()`获取其父 `ClassLoader`，如果获取到 `ClassLoader` 为`null`的话，那么该类是通过 `BootstrapClassLoader` 加载的。
+每个 `ClassLoader` 可以通过`getParent()`获取其父 `ClassLoader`，如果获取到 `ClassLoader` 为`null`的话，那么该类加载器的父类加载器是 `BootstrapClassLoader` 。
 
 ```java
 public abstract class ClassLoader {


### PR DESCRIPTION
判断一个类加载器是不是被BootstrapClassLoader 加载的，应该使用XXXClaissLoader.getClass().getClassLoader()是不是为null来判断，getParent()只是获取类加载器在委派链中的父类加载器，两个是不同概念。我可以自定义一个类加载器，通过new MyClassLoader(null)主动设置parent为null打破双亲委派。但是我的MyClassLoader这个类是被AppClassLoader加载的。具体可以通过一下代码验证：
```java
/**
 * @author simon_jiang
 * @version 1.0
 */
public class ClassLoaderTest {
    public static void main(String[] args) {

        // 创建一个父加载器为null的自定义类加载器
        MyClassLoader myLoader = new MyClassLoader(null);

        // 查看MyClassLoader类是由哪个类加载器加载的
        System.out.println(MyClassLoader.class.getClassLoader());

        // 查看我们创建的myLoader实例的父加载器
        System.out.println(myLoader.getParent()); // 输出：null
    }
}


class MyClassLoader extends ClassLoader {
    public MyClassLoader(ClassLoader parent) {
        super(parent);
    }
}
```