### PR TITLE
修正 Java 10 中的 Optional 增强描述

### DIFF
--- a/docs/java/new-features/java10.md
+++ b/docs/java/new-features/java10.md
@@ -81,11 +81,11 @@ list.stream().collect(Collectors.toUnmodifiableSet());
 
 ## Optional 增强
 
-`Optional` 新增了`orElseThrow()`方法来在没有值时抛出指定的异常。
+`Optional` 新增了一个无参的 `orElseThrow()` 方法，作为带参数的 `orElseThrow(Supplier<? extends X> exceptionSupplier)` 的简化版本，在没有值时默认抛出一个 NoSuchElementException 异常。
 
 ```java
-Optional.ofNullable(cache.getIfPresent(key))
-        .orElseThrow(() -> new PrestoException(NOT_FOUND, "Missing entry found for key: " + key));
+Optional<String> optional = Optional.empty();
+String result = optional.orElseThrow();
 ```
 
 ## 应用程序类数据共享(扩展 CDS 功能)


### PR DESCRIPTION
Java8 中 Optional 已经包含 orElseThrow(Supplier) 方法，但没有无参的 orElseThrow()，到 Java 10 引入了无参的 orElseThrow() 方法。并非原文所述 orElseThrow() 方法是 Java 10 才出现的。

参考：https://github.com/openjdk/jdk/blob/jdk-10%2B46/src/java.base/share/classes/java/util/Optional.java#L369