### PR TITLE
修改为带参数的 poll(timeout, unit) 方法，避免误解和混淆

### DIFF
--- a/docs/java/concurrent/java-concurrent-questions-03.md
+++ b/docs/java/concurrent/java-concurrent-questions-03.md
@@ -399,7 +399,7 @@ public void allowCoreThreadTimeOut(boolean value) {
 
 如果「设置了核心线程的存活时间」或者「线程数量超过了核心线程数量」，则将 `timed` 标记为 `true` ，表明获取任务时需要使用 `poll()` 指定超时时间。
 
-- `timed == true` ：使用 `poll()` 来获取任务。使用 `poll()` 方法获取任务超时的话，则当前线程会退出执行（ `TERMINATED` ），该线程从线程池中被移除。
+- `timed == true` ：使用 `poll(timeout, unit)` 来获取任务。使用 `poll(timeout, unit)` 方法获取任务超时的话，则当前线程会退出执行（ `TERMINATED` ），该线程从线程池中被移除。
 - `timed == false` ：使用 `take()` 来获取任务。使用 `take()` 方法获取任务会让当前线程一直阻塞等待（`WAITING`）。
 
 源码如下：


### PR DESCRIPTION
无参 poll() 会立即从队列中取元素，如果队列为空，直接返回 null（不阻塞）；
带超时参数的 poll(timeout, unit)：在指定时间内等待队列有元素可用。如果超时仍未获取到元素，则返回 null。

建议这里增加参数，避免初学者对阻塞队列的poll()方法有误解