### PR TITLE
docs: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/test.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test.yml`
