### PR TITLE
fix: correct volatile description for AQS state variable

### DIFF
--- a/docs/java/concurrent/aqs.md
+++ b/docs/java/concurrent/aqs.md
@@ -106,10 +106,10 @@ AQS(`AbstractQueuedSynchronizer`)的核心原理图：
 
 AQS 使用 **int 成员变量 `state` 表示同步状态**，通过内置的 **FIFO 线程等待/等待队列** 来完成获取资源线程的排队工作。
 
-`state` 变量由 `volatile` 修饰，用于展示当前临界资源的获取情况。
+`state` 变量由 `volatile` 修饰，用于展示当前临界资源的获取情况。这里 `volatile` 的作用不仅仅是保证可见性，更重要的是通过 happens-before 规则（volatile 变量的写操作先行发生于后续的读操作）防止编译器和处理器对指令进行重排序，从而保证锁语义的正确性。
 
 ```java
-// 共享变量，使用volatile修饰保证线程可见性
+// 共享变量，使用volatile修饰，保证线程可见性并防止指令重排序
 private volatile int state;
 ```
 


### PR DESCRIPTION
## 修复 AQS 中 `state` 变量的 `volatile` 作用描述不准确问题

### 问题描述

关闭 #2516

原文中代码注释为：

```java
// 共享变量，使用volatile修饰保证线程可见性
private volatile int state;
```

以及描述文字仅提到 `volatile` 用于"展示当前临界资源的获取情况"。

### 问题分析

`volatile` 在 AQS `state` 变量中的作用**不仅仅是保证可见性**。实际上，在 AQS 实现中更关键的是通过 **happens-before 规则**来防止指令重排序：

> JMM 的 happens-before 规则规定：volatile 变量的写操作先行发生于后续的读操作。

这保证了锁的获取/释放操作的语义正确性——即线程释放锁（写 `state`）之后，另一个线程获取锁（读 `state`）能看到所有在释放锁之前的操作。

### 修改内容

1. 更新代码注释：`// 共享变量，使用volatile修饰，保证线程可见性并防止指令重排序`
2. 在描述文字中补充 happens-before 规则的解释
