### PR TITLE
更新了可重入锁的举例

### DIFF
--- a/docs/java/concurrent/java-concurrent-questions-02.md
+++ b/docs/java/concurrent/java-concurrent-questions-02.md
@@ -779,7 +779,7 @@ public ReentrantLock(boolean fair) {
 
 **可重入锁** 也叫递归锁，指的是线程可以再次获取自己的内部锁。比如一个线程获得了某个对象的锁，此时这个对象锁还没有释放，当其再次想要获取这个对象的锁的时候还是可以获取的，如果是不可重入锁的话，就会造成死锁。
 
-JDK 提供的所有现成的 `Lock` 实现类，包括 `synchronized` 关键字锁都是可重入的。
+JDK 中常用的锁（如 synchronized、ReentrantLock、ReentrantReadWriteLock）是可重入的，但并不是所有 Lock 实现都支持可重入，例如 StampedLock 就是不可重入的。
 
 在下面的代码中，`method1()` 和 `method2()`都被 `synchronized` 关键字修饰，`method1()`调用了`method2()`。
 


### PR DESCRIPTION
原文“JDK 提供的所有现成的 Lock 实现类，包括 synchronized 关键字锁都是可重入的。”不严谨，JDK 中 synchronized、ReentrantLock、ReentrantReadWriteLock 是可重入的；但不能说 JDK 提供的所有锁都是可重入的，StampedLock 就不是。