### PR TITLE
docs(mysql): add the order by condition to the pagination statement.

### DIFF
--- a/docs/high-performance/deep-pagination-optimization.md
+++ b/docs/high-performance/deep-pagination-optimization.md
@@ -91,13 +91,13 @@ SELECT t1.*
 FROM t_order t1
 INNER JOIN (
     -- 这里的子查询可以利用覆盖索引，性能极高
-    SELECT id FROM t_order LIMIT 1000000, 10
+    SELECT id FROM t_order ORDER BY id LIMIT 1000000, 10
 ) t2 ON t1.id = t2.id;
 ```
 
 **工作原理**:
 
-1. 子查询 `(SELECT id FROM t_order LIMIT 1000000, 10)` 利用主键索引扫描并跳过前 1000000 条记录，返回目标分页的 10 条记录的 ID。
+1. 子查询 `(SELECT id FROM t_order ORDER BY id LIMIT 1000000, 10)` 利用主键索引扫描并跳过前 1000000 条记录，返回目标分页的 10 条记录的 ID。
 2. 通过 `INNER JOIN` 将子查询结果与主表 `t_order` 关联，获取完整的记录数据。
 
 除了使用 INNER JOIN 之外，还可以使用逗号连接子查询。
@@ -105,7 +105,7 @@ INNER JOIN (
 ```sql
 -- 使用逗号进行延迟关联
 SELECT t1.* FROM t_order t1,
-(SELECT id FROM t_order LIMIT 1000000, 10) t2
+(SELECT id FROM t_order ORDER BY id LIMIT 1000000, 10) t2
 WHERE t1.id = t2.id;
 ```
 


### PR DESCRIPTION
### 修改

- 为分页子查询添加显示 `ORDER BY` 条件

测试示例：

```sql
CREATE TABLE EMPLOYEE (
  id INTEGER PRIMARY KEY,
  name VARCHAR(50) NOT NULL,
  dept VARCHAR(50) NOT NULL
);

ALTER TABLE EMPLOYEE ADD INDEX idx_dept(dept);
```

```sql
explain select e.id, name, dept from EMPLOYEE e inner join
( select id from EMPLOYEE limit 100, 10 ) as e2 on e.id = e2.id;
```

[MySQL 在线测试平台](https://onecompiler.com/mysql)

当表中出现多个二级索引（非自然顺序类型），子查询 `select id from EMPLOYEE limit 100, 10` 执行时，优化器发现：

- 方案 A：扫描主键索引树去拿 id。
- 方案 B：扫描 idx_dept 二级索引树去拿 id。

因为二级索引树通常比主键索引树更矮、更窄（占用的磁盘空间和内存更小），MySQL 优化器为了追求极致的 I/O 效率，几乎必然会选择扫描 idx_dept 索引树（在线测试平台结果也是如此）。

但是，idx_dept 索引树是按照 dept 字段的字母顺序 排序的，里面的 id 是完全无序杂乱的。这时候你拿到的前 100 个 id，其物理顺序是跟着部门名称排序的。你的分页顺序瞬间全部乱套，每次翻页都会出现严重的数据重复或遗漏。