### PR TITLE
docs: add OpenTaint (taint-analysis SAST) under a new "Code Security" section

### DIFF
--- a/docs/open-source-project/tools.md
+++ b/docs/open-source-project/tools.md
@@ -16,7 +16,7 @@ icon: "mdi:tools"
 
 ## 代码安全
 
-- [OpenTaint](https://github.com/seqra/opentaint/blob/main/docs/translations/README.zh.md "opentaint")：AI 时代的开源污点分析（Taint Analysis）引擎，面向 Java、Kotlin 和 Spring Boot 应用，可用于应用安全审计（SAST）。它基于字节码进行过程间（inter-procedural）数据流分析，追踪不可信数据在代码中的传播路径，能够检测 SQL 注入、XSS、SSRF、命令注入等 20 多种漏洞。相比传统的模式匹配工具，OpenTaint 还能建模 Spring 的依赖注入、单例 Bean 状态以及 JPA 持久化等跨类、跨请求的数据流，从而发现更深层次的安全问题。核心引擎采用 Apache 2.0 许可证，CLI 与规则集采用 MIT 许可证。官网：[opentaint.org](https://opentaint.org/)；延伸阅读：[Spring 污点分析原理](https://opentaint.org/blog/spring-analyzer/)、[结合 LLM Agent 的低成本安全扫描](https://opentaint.org/blog/appsec-agent/)。
+- [OpenTaint](https://github.com/seqra/opentaint/blob/main/docs/translations/README.zh.md "opentaint")：面向 Java、Kotlin 和 Spring Boot 应用的开源污点分析/SAST 工具，可用于检测 SQL 注入、XSS、SSRF 等安全风险。
 
 ## 项目构建
 

--- a/docs/open-source-project/tools.md
+++ b/docs/open-source-project/tools.md
@@ -1,6 +1,6 @@
 ---
 title: Java 优质开源开发工具
-description: Java优质开源开发工具推荐，涵盖代码质量检查、项目构建、测试框架、容器化部署等开发必备工具精选。
+description: Java优质开源开发工具推荐，涵盖代码质量检查、代码安全分析、项目构建、测试框架、容器化部署等开发必备工具精选。
 category: 开源项目
 icon: "mdi:tools"
 ---
@@ -13,6 +13,10 @@ icon: "mdi:tools"
 - [PMD](https://github.com/pmd/pmd "pmd") : 可扩展的多语言静态代码分析器。
 - [SpotBugs](https://github.com/spotbugs/spotbugs "spotbugs") : FindBugs 的继任者。静态分析工具，用于查找 Java 代码中的错误。
 - [P3C](https://github.com/alibaba/p3c "p3c")：Alibaba Java Coding Guidelines pmd implements and IDE plugin。Eclipse 和 IDEA 上都有该插件。
+
+## 代码安全
+
+- [OpenTaint](https://github.com/seqra/opentaint/blob/main/docs/translations/README.zh.md "opentaint")：AI 时代的开源污点分析（Taint Analysis）引擎，面向 Java、Kotlin 和 Spring Boot 应用，可用于应用安全审计（SAST）。它基于字节码进行过程间（inter-procedural）数据流分析，追踪不可信数据在代码中的传播路径，能够检测 SQL 注入、XSS、SSRF、命令注入等 20 多种漏洞。相比传统的模式匹配工具，OpenTaint 还能建模 Spring 的依赖注入、单例 Bean 状态以及 JPA 持久化等跨类、跨请求的数据流，从而发现更深层次的安全问题。核心引擎采用 Apache 2.0 许可证，CLI 与规则集采用 MIT 许可证。官网：[opentaint.org](https://opentaint.org/)；延伸阅读：[Spring 污点分析原理](https://opentaint.org/blog/spring-analyzer/)、[结合 LLM Agent 的低成本安全扫描](https://opentaint.org/blog/appsec-agent/)。
 
 ## 项目构建
 


### PR DESCRIPTION
## What

Add a `代码安全` (Code Security) section to `docs/open-source-project/tools.md` listing **OpenTaint** — an open-source taint-analysis (SAST) engine for Java / Kotlin / Spring Boot.

It's placed right after `代码质量`: same "run-against-your-code" tooling, but focused on security vulnerabilities rather than code quality, so a separate category keeps it easy to find.

## Why OpenTaint

- On-topic — targets Java / Kotlin / Spring Boot
- Bytecode-level inter-procedural dataflow; detects 20+ vuln classes (SQLi, XSS, SSRF, command injection, etc.)
- Models Spring DI, singleton bean state, and JPA flows that file-by-file matchers miss
- Fully open source (engine is Apache 2.0, CLI and rules are MIT)

The entry links to the Chinese README, the official site, and two deep-dive posts (Spring analysis and LLM-agent with taint workflow).

## Note for reviewers

The copy was drafted with Claude Opus 4.8 — please review the wording and improve any phrasing that reads unnaturally.