### PR TITLE
fix: 修复图片 alt 引号导致的渲染异常

### DIFF
--- a/docs/cs-basics/network/other-network-questions.md
+++ b/docs/cs-basics/network/other-network-questions.md
@@ -113,7 +113,7 @@ head:
 
 先来看一张图（来源于《图解 HTTP》）：
 
-<img src="https://oss.javaguide.cn/github/javaguide/url%E8%BE%93%E5%85%A5%E5%88%B0%E5%B1%95%E7%A4%BA%E5%87%BA%E6%9D%A5%E7%9A%84%E8%BF%87%E7%A8%8B.jpg" alt=“从输入 URL 到页面展示的完整流程” style="zoom:50%" />
+<img src="https://oss.javaguide.cn/github/javaguide/url%E8%BE%93%E5%85%A5%E5%88%B0%E5%B1%95%E7%A4%BA%E5%87%BA%E6%9D%A5%E7%9A%84%E8%BF%87%E7%A8%8B.jpg" alt="从输入 URL 到页面展示的完整流程" style="zoom:50%" />
 
 上图有一个错误需要注意：是 OSPF 不是 OPSF。OSPF（Open Shortest Path First，ospf）开放最短路径优先协议，是由 Internet 工程任务组开发的路由选择协议
 


### PR DESCRIPTION
修复 `docs/cs-basics/network/other-network-questions.md` 中这张图的 `alt` 引号，改为标准 HTML 双引号，避免 GitHub 解析异常导致图片不显示。

关联 issue：#2889

验证：
- `rg -n 'alt=“' docs/cs-basics/network/other-network-questions.md`
- `git diff --check`

风险很低，只影响单处文档渲染，不改正文内容。