### PR TITLE
docs(ai): 补充远程 MCP Inspector 调用示例

### DIFF
--- a/docs/ai/agent/mcp.md
+++ b/docs/ai/agent/mcp.md
@@ -388,6 +388,35 @@ npx @modelcontextprotocol/inspector node build/index.js
 
 生产环境别依赖全局 `python` 里刚好装了 `mcp`。用虚拟环境解释器，或者像上面这样用 `uv run --with mcp ...` 显式声明依赖，会稳一点。如果 Claude Desktop 启动失败，先看 `mcp.log`，别一上来怀疑协议有问题，很多时候只是路径或依赖没配对。
 
+## 用 Inspector 验证远程 Server
+
+上面的例子通过 stdio 启动本地进程。要观察远程 Server 的初始化、工具发现和调用，可以继续用 [MCP Inspector](https://github.com/modelcontextprotocol/inspector)，换成 Streamable HTTP 连接。
+
+这里以 [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) 为例。它提供网页搜索 `web_search` 和网页内容提取 `web_fetch`，匿名入口是 `https://search.parallel.ai/mcp`，不需要 Parallel 账号或 API Key，免费访问有速率限制。
+
+下面使用 Inspector 2.5.0，需要 Node.js 22.19.0 或更高版本。在终端先列出工具：
+
+```bash
+npx --yes @modelcontextprotocol/inspector@2.5.0 --cli \
+  https://search.parallel.ai/mcp --transport http --method tools/list
+```
+
+`--transport http` 指定 Streamable HTTP。Inspector 会先完成初始化，再发送 `tools/list`；返回结果中应能看到 `web_search`、`web_fetch` 及其参数 Schema。这个匿名示例不传 `Authorization` 请求头。
+
+接着调用一次搜索工具，查找 Java 虚拟线程的官方资料：
+
+```bash
+npx --yes @modelcontextprotocol/inspector@2.5.0 --cli \
+  https://search.parallel.ai/mcp --transport http \
+  --method tools/call --tool-name web_search \
+  --tool-arg 'objective=查找 OpenJDK 关于 Java 虚拟线程的官方说明' \
+  --tool-arg 'search_queries=["OpenJDK JEP 444 virtual threads"]'
+```
+
+`objective` 和 `search_queries` 都是必填参数，后者是 JSON 数组。工具结果会包含来源 URL 和内容摘录，可以沿着链接核对答案。排查时要区分连接失败、JSON-RPC 错误和工具返回的 `isError: true`；仅收到 HTTP 200 不代表工具执行成功。
+
+执行搜索或提取时，查询词、目标 URL 和传入的目标描述等上下文会发送给 Parallel，请只使用适合交给第三方处理的内容。这里的 CLI 命令执行完会断开连接，不会给其他 Host 安装服务；如果之后在 Agent 中启用这些工具，Agent 也可能按任务需要自行调用，用完可在对应 Host 中禁用或移除连接。
+
 ## 接入时记录协议 revision
 
 MCP 统一了 Host 与外部工具、数据源之间的发现和调用方式，但不会替代业务鉴权、数据权限和执行审计。一个 Server 在某个 Host 中可用，也不代表换到另一个 Host 后仍支持 Sampling、Elicitation、Tasks 等可选能力。


### PR DESCRIPTION
补充一个可运行的远程 MCP 示例，放在现有的本地天气 Server 和 Inspector 调试示例之后。读者可以用同一个 Inspector CLI，通过 Streamable HTTP 列出工具，再搜索 Java 虚拟线程的官方资料。

选 Parallel 还有一个可以直接核对的理由：[Artificial Analysis 的 Search API 评测](https://artificialanalysis.ai/agents/search-api#details)中，Parallel fast 在 DeepSearchQA 上拿到 80 分，比 Brave web 高 18 分、You.com snippets 高 17 分、TinyFish web 高 13 分。对需要多次搜索、整理资料的任务，这个结果让我觉得它值得放进教程，给读者一个可以亲手试的选择。

下面列出该榜单全部 9 家服务商、19 种模式的 DeepSearchQA F1，方便对照。数据更新日期为 2026-08-31，分数按页面显示的 0–100 刻度记录；在榜单的 provider 筛选器中选 Select all 可以看到所有条目。

| 服务商 | DeepSearchQA F1（按模式） |
| --- | --- |
| Parallel | **fast 80**；advanced 81；basic 79；turbo 70 |
| Brave | web 62；LLM context 78 |
| You.com | snippets 63；highlights 77 |
| TinyFish | web 67 |
| Keenable | pro 70；realtime 70 |
| Tavily | basic 74 |
| Firecrawl | 74 |
| Exa | instant 73；fast 76；auto 78 |
| Perplexity | low 76；medium 81；high 81 |

另一个差距比较明显的项目是 BrowseComp：Parallel fast 是 **72**，Tavily basic 是 **59**，相差 13 分。这个指标考察的是需要多步检索才能找到的事实。

速度也适合拿来做交互式示例：Parallel fast 的平均每任务时间是 **19.4 秒，在全部 19 种模式中最低**。这里是榜单定义的任务时间，包含推算的模型时间和实测搜索时间，不是一次搜索请求的延迟。[时间数据](https://artificialanalysis.ai/agents/search-api#latency) · [评测方法](https://artificialanalysis.ai/methodology/search-api)

这些优势对应具体指标。综合三项评测的 Search Index，Perplexity medium 是 80，Parallel fast 是 73，不能据此说 Parallel 在所有任务上都最好。本教程的[匿名 MCP 默认使用 fast 模式](https://docs.parallel.ai/integrations/mcp/search-mcp)；上面的分数来自 Artificial Analysis 的 Search API 测试，不是对这个 MCP 示例的直接评测。

示例使用 Parallel Search MCP 的匿名入口，不需要账号或 API Key。文中说明了速率限制、请求数据会发送给 Parallel，以及 HTTP 200 和工具执行成功的区别。这次只修改教程，不添加依赖或客户端配置。

验证：

- 使用 Inspector 2.5.0 和 Node.js 24.18.0 执行文中的两条命令，发现 `web_search`、`web_fetch`，搜索成功返回 OpenJDK JEP 444 的链接和摘录。
- 修改文件通过 Prettier 3.4.2、markdownlint-cli2 0.17.1 和 `git diff --check`。
- 未在本地构建站点，页面构建结果仍需 CI 验证，目前 Docs Test 需要维护者操作。

我在 Parallel 工作，这项服务由 Parallel 运营。
